### PR TITLE
Food for Thought. No delay when resolving ajax requests with partial …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+/packages/Antlr.3.4.1.9004/lib
+/packages
+/.vs/config

--- a/SessionStateAsync/Controllers/ResolvedWithSessionAccessController.cs
+++ b/SessionStateAsync/Controllers/ResolvedWithSessionAccessController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.SessionState;
+
+namespace SessionStateAsync.Controllers
+{
+    [OutputCache(NoStore = true, Duration = 0)]
+    [SessionState(SessionStateBehavior.ReadOnly)]
+    public class ResolvedWithSessionAccessController : Controller
+    {
+        public List<string> boxes = new List<string>() { "red", "green", "blue", "black", "gray", "yellow", "orange" };
+
+        public string GetBox()
+        {
+            try
+            {
+                System.Threading.Thread.Sleep(10);
+                object name = System.Web.HttpContext.Current.Session["Name"]; //No exception occurs in read-only mode, kept the performance rate
+                if(null == name)
+                {
+                    Random rnd = new Random();
+                    int index = rnd.Next(0, boxes.Count);
+                    return boxes[index];
+                }
+                else
+                    return (String.Equals(name, "Chris") ? "green" : "orange");
+            }
+            catch(Exception)
+            {
+                return "red";
+            }
+        }
+    }
+}

--- a/SessionStateAsync/Scripts/app.js
+++ b/SessionStateAsync/Scripts/app.js
@@ -1,7 +1,8 @@
 ﻿angular.module('asyncApp', [])
     .value('mvcuri', 'http://localhost:49588/home/getbox')
     .value('mvcurisessionresolved', 'http://localhost:49588/SessionResolved/getbox')
-    .controller('asyncCtrl', function ($http, $scope, mvcuri, mvcurisessionresolved) {
+    .value('mvcuriresolved2', 'http://localhost:49588/ResolvedWithSessionAccess/getBox')
+    .controller('asyncCtrl', function ($http, $scope, mvcuri, mvcurisessionresolved, mvcuriresolved2) {
 
         $scope.boxes = [];
         $scope.showResults = false;
@@ -11,9 +12,11 @@
             var start = new Date();
             var counter = 300;
 
-            
-            if (resolved)
+
+            if (1 == resolved)
                 uri = mvcurisessionresolved;
+            else if (2 == resolved)
+                uri = mvcuriresolved2;
             else
                 uri = mvcuri;
 

--- a/SessionStateAsync/SessionStateAsync.csproj
+++ b/SessionStateAsync/SessionStateAsync.csproj
@@ -22,6 +22,7 @@
     <WebGreaseLibPath>..\packages\WebGrease.1.5.2\lib</WebGreaseLibPath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -104,6 +105,7 @@
   <ItemGroup>
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Controllers\ResolvedWithSessionAccessController.cs" />
     <Compile Include="Controllers\SessionResolvedController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>

--- a/SessionStateAsync/Views/Home/Index.cshtml
+++ b/SessionStateAsync/Views/Home/Index.cshtml
@@ -29,10 +29,13 @@
                         @Html.ActionLink("Start Session", "StartSession")
                     </li>
                     <li>
-                        <a class="links" ng-click="getBoxes()">Not resolved</a>
+                        <a class="links" ng-click="getBoxes(0)">Not resolved</a>
                     </li>
                     <li>
-                        <a class="links" ng-click="getBoxes(true)">Resolved</a>
+                        <a class="links" ng-click="getBoxes(1)">Resolved</a>
+                    </li>
+                    <li>
+                        <a class="links" ng-click="getBoxes(2)">Resolved (Food for Thought)</a>
                     </li>
                     <li>
                         <form class="navbar-form">


### PR DESCRIPTION
Hi,
Food for Thought. It's been found out a way how to get session variables without delay.
The key solution is to use session in read-only mode for an ajax request.

The update additionally has: an added option "Resolved (Food for Thought)", that goes to ResolvedWithSessionAccessController for getBox color, and returns green if it is possible to get 'Chris' name from session container; otherwise, orange.
To use: you needed 1) click 'Start session', 2) check 3 ways of resolving ajax requests.

In my case, I put a line of getting a value from Session to Home's getBox (no affection though). My timing without debug mode in FF: 6250ms, 800, 800. It is much bigger difference comparing to your results. Timing of two 'resolved' tests is alike.

Thank you for this and other posts you have created.
